### PR TITLE
feat: Make team endpoint paginated

### DIFF
--- a/frontend/src/app/layout/component/app.footer.ts
+++ b/frontend/src/app/layout/component/app.footer.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
     standalone: true,
     selector: 'app-footer',
     template: `<div class="layout-footer">
-        <img src="favicon.png" width="25px" />
+        <img src="favicon.png" width="25px" alt="Blog do FT logo" />
         <a
             href="https://blogdoft.com.br"
             target="_blank"

--- a/frontend/src/app/layout/component/app.topbar.ts
+++ b/frontend/src/app/layout/component/app.topbar.ts
@@ -19,7 +19,12 @@ import { LayoutService } from '../service/layout.service';
                 <i class="pi pi-bars"></i>
             </button>
             <a class="layout-topbar-logo" routerLink="/">
-                <img src="favicon.png" width="50px" />
+                <img
+                    src="favicon.png"
+                    width="50px"
+                    ariaLabel="Pull Request Insights logo"
+                    alt="Pull Request Insights logo"
+                />
                 <span>Pull Request Insights</span>
             </a>
         </div>

--- a/frontend/src/app/pages/dashboard/components/filter/filter.component.html
+++ b/frontend/src/app/pages/dashboard/components/filter/filter.component.html
@@ -19,46 +19,24 @@
             </p-iftalabel>
         </div>
         <div class="filter-item">
-            <p-iftalabel>
-                <p-autocomplete
-                    [style]="{ width: '100%' }"
-                    [suggestions]="autoFilteredValue"
-                    optionLabel="name"
-                    dataKey="externalId"
-                    forceSelection
-                    placeholder="Start typing the repositories' team name"
-                    dropdown
-                    lazy="true"
-                    display="chip"
-                    fluid
-                    (onSelect)="onSelectRepoTeam($event)"
-                    (onClear)="onClearRepoTeam($event)"
-                    (completeMethod)="filterTeamRepository($event)"
-                    inputId="repoTeamLookup"
-                ></p-autocomplete>
-                <label for="repoTeamLookup">Filter by teams' repository:</label>
-            </p-iftalabel>
+            <app-paginated-lookup
+                [lookupOptions]="repoTeamLookupOptions"
+                (onLoadData)="loadTeamData($event)"
+                [suggestions]="autoFilteredValue"
+                [isLoading]="isLoading"
+                [pageResponse]="pageResponse"
+                [(fieldKey)]="repoTeamId"
+            />
         </div>
         <div class="filter-item">
-            <p-iftalabel>
-                <p-autocomplete
-                    [style]="{ width: '100%' }"
-                    [suggestions]="autoFilteredValue"
-                    optionLabel="name"
-                    dataKey="externalId"
-                    forceSelection
-                    placeholder="Start typing the team name"
-                    dropdown
-                    lazy="true"
-                    display="chip"
-                    fluid
-                    (onSelect)="onSelectUserTeam($event)"
-                    (onClear)="onClearUserTeam($event)"
-                    (completeMethod)="filterTeamRepository($event)"
-                    inputId="repoTeamLookup2"
-                ></p-autocomplete>
-                <label for="repoTeamLookup2">Filter by team activities:</label>
-            </p-iftalabel>
+            <app-paginated-lookup
+                [lookupOptions]="userTeamLookupOptions"
+                (onLoadData)="loadTeamData($event)"
+                [suggestions]="autoFilteredValue"
+                [isLoading]="isLoading"
+                [pageResponse]="pageResponse"
+                [(fieldKey)]="userTeamId"
+            />
         </div>
     </div>
     <ng-template #footer>

--- a/frontend/src/app/pages/dashboard/components/outliers-table/outliers-table.component.html
+++ b/frontend/src/app/pages/dashboard/components/outliers-table/outliers-table.component.html
@@ -1,16 +1,19 @@
 <p-card header="Outliers">
     <p-table
         [value]="outliers"
-        [tableStyle]="{ 'min-width': '50rem' }"
-        [scrollable]="true"
+        [tableStyle]="{ width: '100%' }"
         styleClass="mt-4"
         sortMode="multiple"
+        [scrollable]="true"
         paginator="true"
-        [rows]="7"
+        [rows]="10"
     >
         <ng-template #header>
             <tr>
-                <th pSortableColumn="outlierField">
+                <th
+                    pSortableColumn="outlierField"
+                    style="width: auto; white-space: nowrap"
+                >
                     <div class="flex items-center">
                         <p-sortIcon
                             field="outlierField"
@@ -53,7 +56,10 @@
                         </p-columnFilter>
                     </div>
                 </th>
-                <th pSortableColumn="outlierValue">
+                <th
+                    pSortableColumn="outlierValue"
+                    style="width: auto; white-space: nowrap"
+                >
                     <div class="flex items-center">
                         <p-sortIcon
                             field="outlierValue"
@@ -62,7 +68,9 @@
                         <span class="mr-2">Value</span>
                     </div>
                 </th>
-                <th><div class="flex justify-between items-center">PR</div></th>
+                <th style="width: auto; white-space: nowrap">
+                    <div class="flex justify-between items-center">PR</div>
+                </th>
             </tr>
         </ng-template>
         <ng-template #body let-outlier>

--- a/frontend/src/app/pages/dashboard/components/pull-request-graph/pull-request-graph.component.html
+++ b/frontend/src/app/pages/dashboard/components/pull-request-graph/pull-request-graph.component.html
@@ -12,6 +12,7 @@
                 [data]="lineChartData"
                 [options]="lineChartOptions"
                 height="100%"
+                ariaLabel="PR Metric analysis graph"
             >
             </p-chart>
         </div>

--- a/frontend/src/app/pages/dashboard/components/reviewer-density-graph/reviewer-density-graph.component.html
+++ b/frontend/src/app/pages/dashboard/components/reviewer-density-graph/reviewer-density-graph.component.html
@@ -6,6 +6,7 @@
         [options]="barChartOptions"
         [plugins]="barChartPlugins"
         height="300px"
+        ariaLabel="Reviewer density graph"
     >
     </p-chart>
     <ng-template #footer></ng-template>

--- a/frontend/src/app/pages/service/report/models/lazy-search-response.ts
+++ b/frontend/src/app/pages/service/report/models/lazy-search-response.ts
@@ -1,0 +1,6 @@
+export interface LazySearchResponse<T> {
+    totalItems: number;
+    totalPages: number;
+    currentPage: number;
+    data: T[];
+}

--- a/frontend/src/app/pages/service/report/models/page-filter.ts
+++ b/frontend/src/app/pages/service/report/models/page-filter.ts
@@ -1,0 +1,5 @@
+export interface PageFilter {
+    page: number;
+    size: number;
+    order?: string;
+}

--- a/frontend/src/app/pages/service/report/models/teams-paginated.ts
+++ b/frontend/src/app/pages/service/report/models/teams-paginated.ts
@@ -1,0 +1,4 @@
+import { LazySearchResponse } from './lazy-search-response';
+import { Team } from './team';
+
+export interface TeamsPaginated extends LazySearchResponse<Team> {}

--- a/frontend/src/app/pages/service/report/teams-repository.service.ts
+++ b/frontend/src/app/pages/service/report/teams-repository.service.ts
@@ -2,22 +2,30 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
-import { Team } from './models/team';
+import { PageFilter } from './models/page-filter';
+import { TeamsPaginated } from './models/teams-paginated';
 
 @Injectable({
     providedIn: 'root'
 })
 export class TeamsRepositoryService {
     private readonly baseUrl = 'http://localhost:8080/code-review';
-    private readonly apiVersion = '1.0';
 
     constructor(private http: HttpClient) {}
 
-    getTeamsByDescription(description: string): Observable<Team[]> {
-        const params = new HttpParams()
+    getTeamsByDescription(
+        description: string,
+        pageFilter: PageFilter
+    ): Observable<TeamsPaginated> {
+        let params = new HttpParams()
             .set('teamName', description)
-            .set('api-version', this.apiVersion);
+            .set('page', pageFilter.page)
+            .set('size', pageFilter.size);
 
-        return this.http.get<Team[]>(`${this.baseUrl}/api/teams`, { params });
+        if (pageFilter.order) params = params.set('order', pageFilter.order);
+
+        return this.http.get<TeamsPaginated>(`${this.baseUrl}/api/teams`, {
+            params
+        });
     }
 }

--- a/frontend/src/app/shared/components/paginated-lookup/paginated-lookup.component.html
+++ b/frontend/src/app/shared/components/paginated-lookup/paginated-lookup.component.html
@@ -1,0 +1,23 @@
+<p-iftalabel>
+    <p-autocomplete
+        [inputId]="lookupOptions.inputId"
+        [style]="{ width: '100%' }"
+        [suggestions]="suggestions"
+        (completeMethod)="onCompleteMethod($event)"
+        (onLazyLoad)="onLazyLoad($event)"
+        (onSelect)="onSelectItem($event)"
+        (onClear)="onClearSelection($event)"
+        [dropdown]="true"
+        [lazy]="true"
+        [virtualScroll]="true"
+        [virtualScrollItemSize]="30"
+        [optionLabel]="lookupOptions.optionLabel"
+        [dataKey]="lookupOptions.dataKey"
+        [forceSelection]="true"
+        [placeholder]="lookupOptions.placeholder"
+        display="chip"
+        [fluid]="true"
+        [showClear]="true"
+    ></p-autocomplete>
+    <label [for]="lookupOptions.inputId">Filter by team activities:</label>
+</p-iftalabel>

--- a/frontend/src/app/shared/components/paginated-lookup/paginated-lookup.component.spec.ts
+++ b/frontend/src/app/shared/components/paginated-lookup/paginated-lookup.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PaginatedLookupComponent } from './paginated-lookup.component';
+
+describe('PaginatedLookupComponent', () => {
+  let component: PaginatedLookupComponent;
+  let fixture: ComponentFixture<PaginatedLookupComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PaginatedLookupComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PaginatedLookupComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/shared/components/paginated-lookup/paginated-lookup.component.ts
+++ b/frontend/src/app/shared/components/paginated-lookup/paginated-lookup.component.ts
@@ -1,0 +1,111 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+    AutoCompleteDropdownClickEvent,
+    AutoCompleteLazyLoadEvent,
+    AutoCompleteModule,
+    AutoCompleteSelectEvent
+} from 'primeng/autocomplete';
+import { IftaLabelModule } from 'primeng/iftalabel';
+
+@Component({
+    selector: 'app-paginated-lookup',
+    imports: [AutoCompleteModule, IftaLabelModule],
+    templateUrl: './paginated-lookup.component.html',
+    styleUrl: './paginated-lookup.component.scss'
+})
+export class PaginatedLookupComponent {
+    @Input()
+    public lookupOptions!: LookupOptions;
+
+    @Input()
+    public suggestions!: any[];
+
+    @Input()
+    public isLoading: boolean = false;
+
+    @Input()
+    public pageResponse!: PageResponse;
+
+    @Input()
+    public fieldKey!: any;
+
+    @Output()
+    public fieldKeyChange: EventEmitter<any> = new EventEmitter<any>();
+
+    @Output()
+    public onLoadData: EventEmitter<LazyQuery> = new EventEmitter<LazyQuery>();
+
+    @Output()
+    public onSelect: EventEmitter<AutoCompleteSelectEvent> =
+        new EventEmitter<AutoCompleteSelectEvent>();
+
+    @Output()
+    public onClear: EventEmitter<Event | undefined> = new EventEmitter<
+        Event | undefined
+    >();
+
+    protected autoFilteredValue!: any[];
+
+    private lastQuery: string = '';
+    private pageSize: number = 0;
+
+    protected onSelectItem($event: AutoCompleteSelectEvent) {
+        this.fieldKey = $event.value[this.lookupOptions.dataKey];
+        this.fieldKeyChange.emit(this.fieldKey);
+        this.onSelect.emit($event);
+    }
+
+    protected onClearSelection($event: Event | undefined) {
+        this.fieldKey = null;
+        this.fieldKeyChange.emit(this.fieldKey);
+        this.onClear.emit($event);
+    }
+
+    protected onCompleteMethod(event: AutoCompleteDropdownClickEvent): void {
+        this.lastQuery = event.query;
+        this.pageResponse.currentPage = 0;
+        this.onLoadData.emit({
+            page: 0,
+            size: this.pageSize,
+            params: event.query,
+            lazyCall: false
+        });
+    }
+
+    protected onLazyLoad(event: AutoCompleteLazyLoadEvent): void {
+        const page = this.pageResponse.currentPage + 1;
+        if (event.last != this.suggestions.length) return;
+
+        if (page > this.pageResponse.totalPages) return;
+
+        if (this.isLoading) return;
+
+        this.onLoadData.emit({
+            page: page,
+            size: this.pageSize,
+            params: this.lastQuery,
+            lazyCall: true
+        });
+    }
+}
+
+export interface LazyQuery {
+    params: any;
+    page: number;
+    size: number;
+    order?: string;
+    lazyCall: boolean;
+}
+
+export interface PageResponse {
+    totalItems: number;
+    totalPages: number;
+    currentPage: number;
+}
+
+export interface LookupOptions {
+    placeholder: string;
+    dataKey: string;
+    optionLabel: string;
+    inputId: string | undefined;
+}


### PR DESCRIPTION
This is important to avoid full scan when trying to select just on team on combo lookups. Also, when we work on crud for teams, this will be also relevant for performance.