### PR TITLE
feat: Make team endpoint paginated

### DIFF
--- a/backend/.editorconfig
+++ b/backend/.editorconfig
@@ -228,6 +228,9 @@ dotnet_diagnostic.SA1305.severity=warning
 # SA1412: Store file as  UTF-8
 dotnet_diagnostic.SA1412.severity=none
 
+# SA1010: Opening square brackets should not be preceded by a space.
+dotnet_diagnostic.SA1010.severity=none
+
 # CSharp code style settings:
 [*.cs]
 # Newline settings
@@ -327,6 +330,9 @@ dotnet_diagnostic.SA1600.severity = none
 
 # CA1848: Use the LoggerMessage delegates
 dotnet_diagnostic.CA1848.severity = none
+
+# S3925: Update this implementation of 'ISerializable' to conform to the recommended serialization pattern. Add a 'protected' constructor 'PaginatedSqlBuilderException(SerializationInfo, StreamingContext)'.
+dotnet_diagnostic.S3925.severity = none
 
 [src/CodeStyle/**.{cs,vb}]
 # warning RS0005: Do not use generic CodeAction.Create to create CodeAction

--- a/backend/src/CodeReviewAnalyzer.Api/Models/Paging/PaginatedRequest.cs
+++ b/backend/src/CodeReviewAnalyzer.Api/Models/Paging/PaginatedRequest.cs
@@ -1,0 +1,31 @@
+using CodeReviewAnalyzer.Application.Models.PagingModels;
+
+namespace CodeReviewAnalyzer.Api.Models.Paging;
+
+public class PaginatedRequest
+{
+    /// <summary>
+    /// Gets the page number to be retrieved. Defaults to 0.
+    /// </summary>
+    /// <example>1</example>
+    public int Page { get; init; } = 0;
+
+    /// <summary>
+    /// Gets the number of items to be retrieved per page. Defaults to 10.
+    /// </summary>
+    /// <example>15</example>
+    public int Size { get; init; } = 10;
+
+    /// <summary>
+    /// Gets the order in which the data should be sorted.
+    /// </summary>
+    /// <example>"name ASC"</example>
+    public string? Order { get; init; }
+
+    internal PageFilter ToPageFilter() => new()
+    {
+        Page = Page,
+        Size = Size,
+        Order = Order,
+    };
+}

--- a/backend/src/CodeReviewAnalyzer.Api/Models/Paging/PaginatedResponse.cs
+++ b/backend/src/CodeReviewAnalyzer.Api/Models/Paging/PaginatedResponse.cs
@@ -1,0 +1,26 @@
+using CodeReviewAnalyzer.Application.Models.PagingModels;
+
+namespace CodeReviewAnalyzer.Api.Models.Paging;
+
+public abstract class PaginatedResponse<TData>
+{
+    protected PaginatedResponse(
+        PageReturn<TData> pageResult,
+        PaginatedRequest pageFilter)
+    {
+        Data = pageResult.Data;
+        TotalItems = pageResult.TotalItem;
+        CurrentPage = pageFilter.Page;
+        TotalPages = TotalItems == 0
+            ? 0
+            : (TotalItems / pageFilter.Size) + 1;
+    }
+
+    public TData Data { get; init; }
+
+    public int CurrentPage { get; init; }
+
+    public int TotalItems { get; init; }
+
+    public int TotalPages { get; init; }
+}

--- a/backend/src/CodeReviewAnalyzer.Api/Models/Teams/TeamsPaginated.cs
+++ b/backend/src/CodeReviewAnalyzer.Api/Models/Teams/TeamsPaginated.cs
@@ -1,0 +1,14 @@
+using CodeReviewAnalyzer.Api.Models.Paging;
+using CodeReviewAnalyzer.Application.Models;
+using CodeReviewAnalyzer.Application.Models.PagingModels;
+
+namespace CodeReviewAnalyzer.Api.Models.Teams;
+
+public class TeamsPaginated(
+    PageReturn<IEnumerable<Team>> pageResult,
+    PaginatedRequest pageFilter)
+    : PaginatedResponse<IEnumerable<Team>>(
+        pageResult,
+        pageFilter)
+{
+}

--- a/backend/src/CodeReviewAnalyzer.Application/Models/PagingModels/PageFilter.cs
+++ b/backend/src/CodeReviewAnalyzer.Application/Models/PagingModels/PageFilter.cs
@@ -1,0 +1,10 @@
+namespace CodeReviewAnalyzer.Application.Models.PagingModels;
+
+public readonly struct PageFilter
+{
+    public int Page { get; init; }
+
+    public int Size { get; init; }
+
+    public string? Order { get; init; }
+}

--- a/backend/src/CodeReviewAnalyzer.Application/Models/PagingModels/PageReturn.cs
+++ b/backend/src/CodeReviewAnalyzer.Application/Models/PagingModels/PageReturn.cs
@@ -1,0 +1,8 @@
+namespace CodeReviewAnalyzer.Application.Models.PagingModels;
+
+public class PageReturn<T>(T data, int totalItem)
+{
+    public T Data { get; init; } = data;
+
+    public int TotalItem { get; init; } = totalItem;
+}

--- a/backend/src/CodeReviewAnalyzer.Application/Repositories/ITeams.cs
+++ b/backend/src/CodeReviewAnalyzer.Application/Repositories/ITeams.cs
@@ -1,4 +1,5 @@
 using CodeReviewAnalyzer.Application.Models;
+using CodeReviewAnalyzer.Application.Models.PagingModels;
 
 namespace CodeReviewAnalyzer.Application.Repositories;
 
@@ -8,7 +9,9 @@ public interface ITeams
 
     Task DeactivateAsync(Guid id);
 
-    Task<IEnumerable<Team>> QueryBy(string? teamName);
+    Task<PageReturn<IEnumerable<Team>>> QueryBy(
+        PageFilter pageFilter,
+        string? teamName);
 
     Task<Team?> QueryByIdAsync(string id);
 

--- a/backend/src/CodeReviewAnalyzer.Database/Contexts/Impl/DapperDatabaseFacade.cs
+++ b/backend/src/CodeReviewAnalyzer.Database/Contexts/Impl/DapperDatabaseFacade.cs
@@ -17,6 +17,11 @@ public sealed class DapperDatabaseFacade(
         object? param = null) =>
         _connection.QueryAsync<T>(sql, param);
 
+    public async Task<T> QueryFirstAsync<T>(
+        string sql,
+        object? param = null) =>
+        await _connection.QueryFirstAsync<T>(sql, param);
+
     public async Task<int> ExecuteAsync(string sql, object? param = null) =>
         await _connection.ExecuteAsync(sql, param);
 

--- a/backend/src/CodeReviewAnalyzer.Database/Exceptions/PaginatedSqlBuilderException.cs
+++ b/backend/src/CodeReviewAnalyzer.Database/Exceptions/PaginatedSqlBuilderException.cs
@@ -1,0 +1,19 @@
+namespace CodeReviewAnalyzer.Database.Exceptions;
+
+[Serializable]
+public class PaginatedSqlBuilderException : Exception
+{
+    public PaginatedSqlBuilderException()
+    {
+    }
+
+    public PaginatedSqlBuilderException(string message)
+        : base(message)
+    {
+    }
+
+    public PaginatedSqlBuilderException(string message, Exception inner)
+        : base(message, inner)
+    {
+    }
+}

--- a/backend/src/CodeReviewAnalyzer.Database/Extensions/StringExtensions.cs
+++ b/backend/src/CodeReviewAnalyzer.Database/Extensions/StringExtensions.cs
@@ -1,0 +1,23 @@
+namespace CodeReviewAnalyzer.Database.Extensions;
+
+public static class StringExtensions
+{
+    /// <summary>
+    /// Replaces all occurrences of `oldString` by `newString` at value.
+    /// </summary>
+    /// <param name="value">The string to be analyzed.</param>
+    /// <param name="oldString">Token to be replaced.</param>
+    /// <param name="newString">Token to be introduced.</param>
+    /// <returns>The same string with tokens replaced.</returns>
+    public static string ReplaceAll(this string value, string oldString, string newString)
+    {
+        if (!value.Contains(oldString))
+        {
+            return value;
+        }
+
+        return value
+            .Replace(oldString, newString)
+            .ReplaceAll(oldString, newString);
+    }
+}

--- a/backend/src/CodeReviewAnalyzer.Database/Services/OrderByResolver.cs
+++ b/backend/src/CodeReviewAnalyzer.Database/Services/OrderByResolver.cs
@@ -1,0 +1,92 @@
+using CodeReviewAnalyzer.Database.Extensions;
+using System.Collections.Immutable;
+using System.Text;
+
+namespace CodeReviewAnalyzer.Database.Services;
+
+public class OrderByResolver
+{
+    private const string Ascending = "ASC";
+    private const string Descending = "DESC";
+
+    private readonly ImmutableDictionary<string, string> _fromTo;
+
+    public OrderByResolver(Dictionary<string, string> fromTo)
+        : this(fromTo.ToImmutableDictionary())
+    {
+    }
+
+    public OrderByResolver(ImmutableDictionary<string, string>? fromTo) =>
+        _fromTo = fromTo ?? new Dictionary<string, string>().ToImmutableDictionary();
+
+    public StringBuilder Resolve(string? userOrderBy)
+    {
+        var orderBy = new StringBuilder();
+        if (string.IsNullOrWhiteSpace(userOrderBy))
+        {
+            return orderBy;
+        }
+
+        var fieldsList = MapUserToSqlFields(userOrderBy);
+        if (!fieldsList.Any())
+        {
+            return orderBy;
+        }
+
+        var orderFields = string.Join(", ", fieldsList);
+
+        return orderBy
+            .AppendLine("ORDER BY")
+            .AppendLine(orderFields);
+    }
+
+    private static IEnumerable<(string FieldName, string Ordering)> NormalizeInput(
+        string userOrderBy) => userOrderBy
+        .Split(",")
+        .Select(field =>
+        {
+            var fieldMeta = field.Trim()
+                .ReplaceAll("  ", " ")
+                .Split(' ');
+            if (fieldMeta.Length == 2)
+            {
+                var ordering = fieldMeta[1].ToUpper() == Descending
+                    ? fieldMeta[1].ToUpper()
+                    : Ascending;
+                return (FieldName: fieldMeta[0], Ordering: ordering);
+            }
+
+            return (FieldName: fieldMeta[0], Ordering: Ascending);
+        });
+
+    private IEnumerable<string> MapUserToSqlFields(string userOrderBy)
+    {
+        if (string.IsNullOrWhiteSpace(userOrderBy))
+        {
+            return Array.Empty<string>();
+        }
+
+        var fields = NormalizeInput(userOrderBy);
+
+        return MapFields(fields);
+    }
+
+    private IEnumerable<string> MapFields(
+        IEnumerable<(string FieldName, string Ordering)> fieldsMeta) => fieldsMeta
+        .Aggregate(new List<string>(), (orders, fieldMeta) =>
+        {
+            var mappedField = _fromTo.TryGetValue(fieldMeta.FieldName, out var sqlFieldName);
+
+            if (string.IsNullOrWhiteSpace(sqlFieldName))
+            {
+                return orders;
+            }
+
+            if (mappedField)
+            {
+                orders.Add($"{sqlFieldName} {fieldMeta.Ordering}");
+            }
+
+            return orders;
+        });
+}

--- a/backend/src/CodeReviewAnalyzer.Database/Services/PageCountStmt.cs
+++ b/backend/src/CodeReviewAnalyzer.Database/Services/PageCountStmt.cs
@@ -1,0 +1,12 @@
+using System.Text;
+
+namespace CodeReviewAnalyzer.Database.Services;
+
+internal static class PageCountStmt
+{
+    private const string SqlCount = "select count(1) from ({0}) as counter_result";
+
+    public static StringBuilder BuildCountSql(StringBuilder sql) =>
+        new StringBuilder()
+            .AppendFormat(SqlCount, sql);
+}

--- a/backend/src/CodeReviewAnalyzer.Database/Services/PaginatedSqlBuilder.cs
+++ b/backend/src/CodeReviewAnalyzer.Database/Services/PaginatedSqlBuilder.cs
@@ -1,0 +1,87 @@
+using CodeReviewAnalyzer.Application.Models.PagingModels;
+using CodeReviewAnalyzer.Database.Exceptions;
+using System.Collections.Immutable;
+using System.Text;
+
+namespace CodeReviewAnalyzer.Database.Services;
+
+internal class PaginatedSqlBuilder
+{
+    private readonly WhereBuilder _where;
+    private string? _resultSet;
+    private PageFilter _pageFilter;
+    private ImmutableDictionary<string, string>? _orderMap;
+
+    public PaginatedSqlBuilder()
+    {
+        _where = new WhereBuilder();
+    }
+
+    public (StringBuilder Query, StringBuilder QuerySize) Build()
+    {
+        ValidateBuild();
+
+        var resultSet = new StringBuilder(_resultSet);
+
+        var where = _where.Build();
+
+        var orderBy = new OrderByResolver(_orderMap)
+            .Resolve(_pageFilter.Order);
+
+        var paging = SqlPagination.From(_pageFilter);
+
+        resultSet
+            .Append(where);
+
+        var querySize = PageCountStmt.BuildCountSql(resultSet);
+        var paginatedQuery = resultSet
+            .AppendLine()
+            .Append(orderBy)
+            .AppendLine(paging);
+
+        return (Query: paginatedQuery, QuerySize: querySize);
+    }
+
+    public PaginatedSqlBuilder WithResultSet(string resultSet)
+    {
+        _resultSet = resultSet;
+        return this;
+    }
+
+    public PaginatedSqlBuilder MappingOrderWith(string key, string value) =>
+        MappingOrderWith(new Dictionary<string, string> { { key, value } });
+
+    public PaginatedSqlBuilder MappingOrderWith(Dictionary<string, string> orderMap) =>
+        MappingOrderWith(orderMap.ToImmutableDictionary());
+
+    public PaginatedSqlBuilder MappingOrderWith(ImmutableDictionary<string, string> orderMap)
+    {
+        _orderMap = orderMap;
+        return this;
+    }
+
+    public PaginatedSqlBuilder WithPagination(PageFilter pageFilter)
+    {
+        _pageFilter = pageFilter;
+        return this;
+    }
+
+    public PaginatedSqlBuilder WithWhere(Action<WhereBuilder> where)
+    {
+        where(_where);
+        return this;
+    }
+
+    private void ValidateBuild()
+    {
+        if (string.IsNullOrWhiteSpace(_resultSet))
+        {
+            throw new PaginatedSqlBuilderException();
+        }
+
+        if (_pageFilter.Equals((PageFilter)default))
+        {
+            throw new PaginatedSqlBuilderException();
+        }
+    }
+}

--- a/backend/src/CodeReviewAnalyzer.Database/Services/SqlPagination.cs
+++ b/backend/src/CodeReviewAnalyzer.Database/Services/SqlPagination.cs
@@ -1,0 +1,38 @@
+using CodeReviewAnalyzer.Application.Models.PagingModels;
+
+namespace CodeReviewAnalyzer.Database.Services;
+
+internal static class SqlPagination
+{
+    internal const int MinPageNumber = 0;
+    internal const int MinPageSize = 1;
+    internal const int MaxPageSize = 255;
+
+    private static readonly string _pageNumberRangeError =
+        $"Page number must be between 0 and {int.MaxValue}";
+
+    private static readonly string _pageSizeRangeError =
+        $"Page size must be between {MinPageSize} and {MaxPageSize}";
+
+    public static string GetPagination(int pageNumber, int pageSize) =>
+         From(new PageFilter { Page = pageNumber, Size = pageSize });
+
+    public static string From(PageFilter pagination)
+    {
+        if (pagination.Page < MinPageNumber)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(pagination),
+                _pageNumberRangeError);
+        }
+
+        if (pagination.Size < MinPageSize || pagination.Size > MaxPageSize)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(pagination),
+                _pageSizeRangeError);
+        }
+
+        return $"LIMIT {pagination.Size} OFFSET {pagination.Page * pagination.Size}";
+    }
+}

--- a/eng/docker/postgres/init-sql/02-mascarade.sql
+++ b/eng/docker/postgres/init-sql/02-mascarade.sql
@@ -1,6 +1,285 @@
 DO $$
 BEGIN
-    RAISE NOTICE 'second file';
-  
+    IF EXISTS (SELECT 1 FROM public."USERS" LIMIT 1) THEN
+        RAISE NOTICE 'Oculting names';  
+        -- 1
+        UPDATE public."USERS"
+        SET "NAME" = 'Maria Oliveira'
+        WHERE "EXTERNAL_IDENTIFIER" = 'cdcf7863-0aa5-6b51-a799-5638240f3f4b';
 
+        -- 2
+        UPDATE public."USERS"
+        SET "NAME" = 'João Silva'
+        WHERE "EXTERNAL_IDENTIFIER" = '93688bea-85a8-6658-b620-e00b63496949';
+
+        -- 3
+        UPDATE public."USERS"
+        SET "NAME" = 'Ana Santos'
+        WHERE "EXTERNAL_IDENTIFIER" = '40afcddd-5544-4f22-bad7-dedbda22fdf4';
+
+        -- 4
+        UPDATE public."USERS"
+        SET "NAME" = 'Pedro Santos'
+        WHERE "EXTERNAL_IDENTIFIER" = '3c04c350-ef63-64ee-ba49-99fc02beb701';
+
+        -- 5
+        UPDATE public."USERS"
+        SET "NAME" = 'Juliana Ferreira'
+        WHERE "EXTERNAL_IDENTIFIER" = 'fae270e9-2d2f-63af-b6da-7fa3351ec793';
+
+        -- 6
+        UPDATE public."USERS"
+        SET "NAME" = 'Lucas Oliveira'
+        WHERE "EXTERNAL_IDENTIFIER" = 'b9bc9da4-38ea-65e2-86f0-8194b996726b';
+
+        -- 7
+        UPDATE public."USERS"
+        SET "NAME" = 'Fernanda Costa'
+        WHERE "EXTERNAL_IDENTIFIER" = 'd1ca6a7b-871c-650e-acfb-e07b77df3c7e';
+
+        -- 8
+        UPDATE public."USERS"
+        SET "NAME" = 'Matheus Costa'
+        WHERE "EXTERNAL_IDENTIFIER" = '4f768894-c3aa-4317-a9bc-8e1e0959d3f4';
+
+        -- 9
+        UPDATE public."USERS"
+        SET "NAME" = 'Camila Rodrigues'
+        WHERE "EXTERNAL_IDENTIFIER" = 'e028e482-cd14-697a-a828-00e471729ce5';
+
+        -- 10
+        UPDATE public."USERS"
+        SET "NAME" = 'Bruno Rodrigues'
+        WHERE "EXTERNAL_IDENTIFIER" = '14d9837c-d763-6981-98b7-64bb6b75d05b';
+
+        -- 11
+        UPDATE public."USERS"
+        SET "NAME" = 'Patricia Almeida'
+        WHERE "EXTERNAL_IDENTIFIER" = 'e955dc19-0860-6d67-a712-f6793b57d193';
+
+        -- 12
+        UPDATE public."USERS"
+        SET "NAME" = 'Gabriel Almeida'
+        WHERE "EXTERNAL_IDENTIFIER" = '8b96c1fc-5860-6e77-8ab3-8397ea19a05b';
+
+        -- 13
+        UPDATE public."USERS"
+        SET "NAME" = 'Leticia Lima'
+        WHERE "EXTERNAL_IDENTIFIER" = '83dbcdca-02d5-6d07-81ea-d81b1e448af8';
+
+        -- 14
+        UPDATE public."USERS"
+        SET "NAME" = 'Felipe Lima'
+        WHERE "EXTERNAL_IDENTIFIER" = '9b9f1cee-6487-6787-8951-c7405010e953';
+
+        -- 15
+        UPDATE public."USERS"
+        SET "NAME" = 'Daniela Souza'
+        WHERE "EXTERNAL_IDENTIFIER" = '6a102c01-3320-610b-924b-e07bc5be2a09';
+
+        -- 16
+        UPDATE public."USERS"
+        SET "NAME" = 'Ricardo Souza'
+        WHERE "EXTERNAL_IDENTIFIER" = '816a8b0c-337b-6e1e-bc4d-045c3243a00c';
+
+        -- 17
+        UPDATE public."USERS"
+        SET "NAME" = 'Adriana Martins'
+        WHERE "EXTERNAL_IDENTIFIER" = '9e5693fd-8b04-69ec-832a-9fa909e4cdda';
+
+        -- 18
+        UPDATE public."USERS"
+        SET "NAME" = 'André Martins'
+        WHERE "EXTERNAL_IDENTIFIER" = '2ea60914-fb45-6cea-af34-e0faa91245b0';
+
+        -- 19
+        UPDATE public."USERS"
+        SET "NAME" = 'Beatriz Pereira'
+        WHERE "EXTERNAL_IDENTIFIER" = 'c9be12cb-9f08-6181-95e4-eff471d0b74b';
+
+        -- 20
+        UPDATE public."USERS"
+        SET "NAME" = 'Carlos Pereira'
+        WHERE "EXTERNAL_IDENTIFIER" = 'ff2e6db4-8b5d-61e6-988d-10f231cc9d49';
+
+        -- 21
+        UPDATE public."USERS"
+        SET "NAME" = 'Renata Gomes'
+        WHERE "EXTERNAL_IDENTIFIER" = '5acf45d3-f138-6950-9c38-aad792333713';
+
+        -- 22
+        UPDATE public."USERS"
+        SET "NAME" = 'Diego Gomes'
+        WHERE "EXTERNAL_IDENTIFIER" = 'f7e7c9aa-d42f-6dbb-9d5f-871f3a3d76a5';
+
+        -- 23
+        UPDATE public."USERS"
+        SET "NAME" = 'Tatiana Silva'
+        WHERE "EXTERNAL_IDENTIFIER" = '57508f54-9810-6aa0-b648-a445a45a998b';
+
+        -- 24
+        UPDATE public."USERS"
+        SET "NAME" = 'Rafael Silva'
+        WHERE "EXTERNAL_IDENTIFIER" = '307fdf6c-3839-6f23-b1b1-e87d4de6f39c';
+
+        -- 25
+        UPDATE public."USERS"
+        SET "NAME" = 'Carla Mendes'
+        WHERE "EXTERNAL_IDENTIFIER" = '36db4570-7fb9-69dc-afbd-9ee1b7382745';
+
+        -- 26
+        UPDATE public."USERS"
+        SET "NAME" = 'Vinícius Mendes'
+        WHERE "EXTERNAL_IDENTIFIER" = 'c393bd83-69d5-6e36-a47d-00d91314b01c';
+
+        -- 27
+        UPDATE public."USERS"
+        SET "NAME" = 'Vanessa Rocha'
+        WHERE "EXTERNAL_IDENTIFIER" = '76ce5ba2-d485-6270-b3e9-fcaf9540c2fe';
+
+        -- 28
+        UPDATE public."USERS"
+        SET "NAME" = 'Alexandre Rocha'
+        WHERE "EXTERNAL_IDENTIFIER" = '8b0ef471-f8a3-6cf2-a882-d47d3c760620';
+
+        -- 29
+        UPDATE public."USERS"
+        SET "NAME" = 'Aline Dias'
+        WHERE "EXTERNAL_IDENTIFIER" = 'dc4e32d9-7c54-6281-a054-0327969abf3c';
+
+        -- 30
+        UPDATE public."USERS"
+        SET "NAME" = 'Leonardo Dias'
+        WHERE "EXTERNAL_IDENTIFIER" = '2ede2744-4510-40ba-b79b-3127859e1323';
+
+        -- 31
+        UPDATE public."USERS"
+        SET "NAME" = 'Mariana Barbosa'
+        WHERE "EXTERNAL_IDENTIFIER" = '9f09dd3b-b69c-60aa-b081-38995f178a9f';
+
+        -- 32
+        UPDATE public."USERS"
+        SET "NAME" = 'Thiago Barbosa'
+        WHERE "EXTERNAL_IDENTIFIER" = '4e1834a6-2680-67fe-b878-62a28a35c4f2';
+
+        -- 33
+        UPDATE public."USERS"
+        SET "NAME" = 'Priscila Ribeiro'
+        WHERE "EXTERNAL_IDENTIFIER" = '6824977e-9b62-690a-99b5-542f2ac174d5';
+
+        -- 34
+        UPDATE public."USERS"
+        SET "NAME" = 'Daniel Ribeiro'
+        WHERE "EXTERNAL_IDENTIFIER" = 'bff8b6ee-1097-6403-8629-ec6eeeeb772a';
+
+        -- 35
+        UPDATE public."USERS"
+        SET "NAME" = 'Paula Cardoso'
+        WHERE "EXTERNAL_IDENTIFIER" = 'a1b930f9-b185-6ba8-9082-3675185cc4e8';
+
+        -- 36
+        UPDATE public."USERS"
+        SET "NAME" = 'Gustavo Cardoso'
+        WHERE "EXTERNAL_IDENTIFIER" = '0e8f2ad6-a866-64c9-b630-636dfe512086';
+
+        -- 37
+        UPDATE public."USERS"
+        SET "NAME" = 'Simone Moreira'
+        WHERE "EXTERNAL_IDENTIFIER" = '21bca9ab-591b-461d-a832-aa4e64da856d';
+
+        -- 38
+        UPDATE public."USERS"
+        SET "NAME" = 'Rodrigo Moreira'
+        WHERE "EXTERNAL_IDENTIFIER" = '45cddc82-99ae-620a-81a8-3e86077e00a3';
+
+        -- 39
+        UPDATE public."USERS"
+        SET "NAME" = 'Ingrid Araújo'
+        WHERE "EXTERNAL_IDENTIFIER" = '5fad3dd6-9f5a-4ff2-877d-b4f38de24ea9';
+
+        -- 40
+        UPDATE public."USERS"
+        SET "NAME" = 'Marcelo Araújo'
+        WHERE "EXTERNAL_IDENTIFIER" = '879fcccd-786d-6b15-b91d-1a5bcef7b771';
+
+        -- 41
+        UPDATE public."USERS"
+        SET "NAME" = 'Rafaela Teixeira'
+        WHERE "EXTERNAL_IDENTIFIER" = '235fa6ce-a70e-4a19-8ad8-4cd1ce05f10e';
+
+        -- 42
+        UPDATE public."USERS"
+        SET "NAME" = 'Eduardo Teixeira'
+        WHERE "EXTERNAL_IDENTIFIER" = '9e06cbfe-c407-655a-b041-bf229cc63281';
+
+        -- 43
+        UPDATE public."USERS"
+        SET "NAME" = 'Luana Figueiredo'
+        WHERE "EXTERNAL_IDENTIFIER" = '4838ae18-449b-663c-9a2b-54a1cb33a7cd';
+
+        -- 44
+        UPDATE public."USERS"
+        SET "NAME" = 'Victor Figueiredo'
+        WHERE "EXTERNAL_IDENTIFIER" = '746e8fef-443b-65c1-9aa2-5a28d2278b65';
+
+        -- 45
+        UPDATE public."USERS"
+        SET "NAME" = 'Sabrina Correia'
+        WHERE "EXTERNAL_IDENTIFIER" = 'f76304b6-d58d-603e-af55-bfafedc9fed6';
+
+        -- 46
+        UPDATE public."USERS"
+        SET "NAME" = 'Samuel Correia'
+        WHERE "EXTERNAL_IDENTIFIER" = '8faa854d-602b-63ec-967f-44098392cb31';
+
+        -- 47
+        UPDATE public."USERS"
+        SET "NAME" = 'Gabriela Cunha'
+        WHERE "EXTERNAL_IDENTIFIER" = 'e47e797e-c77e-6084-aba8-686b1db20913';
+
+        -- 48
+        UPDATE public."USERS"
+        SET "NAME" = 'Marcos Cunha'
+        WHERE "EXTERNAL_IDENTIFIER" = '5fb7a348-89ea-649b-85a1-c74e1f625cb4';
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM public."REPOSITORIES" LIMIT 1) THEN
+        RAISE NOTICE 'Oculting repositories';  
+
+        WITH repos AS (
+            SELECT id, ROW_NUMBER() OVER (ORDER BY id) AS rn
+            FROM public."REPOSITORIES"
+        )
+        UPDATE public."REPOSITORIES" r
+        SET "name" = 'Um repositório muito loko ' || repos.rn,
+            remote_url = 'https://example.com/repo/' || repos.rn
+        FROM repos
+        WHERE r.id = repos.id;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM public."REPOSITORIES" LIMIT 1) THEN
+        RAISE NOTICE 'Oculting repositories';  
+
+        WITH pr AS (
+            SELECT "ID", ROW_NUMBER() OVER (ORDER BY "ID") AS rn
+            FROM public."PULL_REQUEST"
+        )
+        UPDATE public."PULL_REQUEST" r
+        SET "TITLE" = 'Um pull request muito loko ' || pr.rn
+          , "URL"='https://blogdoft.com.br'
+        FROM pr
+        WHERE r."ID" = pr."ID";
+    END IF;
+
+    IF EXISTS (select 1 from public."PULL_REQUEST_COMMENTS" LIMIT 1) THEN
+        RAISE NOTICE 'Oculting comments';
+        WITH prc AS (
+            SELECT "ID", ROW_NUMBER() OVER (ORDER BY "ID") AS rn
+            FROM public."PULL_REQUEST_COMMENTS"
+        )
+        UPDATE public."PULL_REQUEST_COMMENTS" r
+        SET "COMMENT" = '[DICA] É sério isso? Acho que você precisa acessar o https://blogdoft.com.br pra entender melhor ' || pr.rn
+        FROM prc
+        WHERE r."ID" = prc."ID";
+    END IF;
 END $$;

--- a/frontend/src/app/layout/component/app.footer.ts
+++ b/frontend/src/app/layout/component/app.footer.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
     standalone: true,
     selector: 'app-footer',
     template: `<div class="layout-footer">
-        <img src="favicon.png" width="25px" />
+        <img src="favicon.png" width="25px" alt="Blog do FT logo" />
         <a
             href="https://blogdoft.com.br"
             target="_blank"

--- a/frontend/src/app/layout/component/app.topbar.ts
+++ b/frontend/src/app/layout/component/app.topbar.ts
@@ -19,7 +19,12 @@ import { LayoutService } from '../service/layout.service';
                 <i class="pi pi-bars"></i>
             </button>
             <a class="layout-topbar-logo" routerLink="/">
-                <img src="favicon.png" width="50px" />
+                <img
+                    src="favicon.png"
+                    width="50px"
+                    ariaLabel="Pull Request Insights logo"
+                    alt="Pull Request Insights logo"
+                />
                 <span>Pull Request Insights</span>
             </a>
         </div>

--- a/frontend/src/app/pages/dashboard/components/filter/filter.component.html
+++ b/frontend/src/app/pages/dashboard/components/filter/filter.component.html
@@ -19,46 +19,24 @@
             </p-iftalabel>
         </div>
         <div class="filter-item">
-            <p-iftalabel>
-                <p-autocomplete
-                    [style]="{ width: '100%' }"
-                    [suggestions]="autoFilteredValue"
-                    optionLabel="name"
-                    dataKey="externalId"
-                    forceSelection
-                    placeholder="Start typing the repositories' team name"
-                    dropdown
-                    lazy="true"
-                    display="chip"
-                    fluid
-                    (onSelect)="onSelectRepoTeam($event)"
-                    (onClear)="onClearRepoTeam($event)"
-                    (completeMethod)="filterTeamRepository($event)"
-                    inputId="repoTeamLookup"
-                ></p-autocomplete>
-                <label for="repoTeamLookup">Filter by teams' repository:</label>
-            </p-iftalabel>
+            <app-paginated-lookup
+                [lookupOptions]="repoTeamLookupOptions"
+                (onLoadData)="loadTeamData($event)"
+                [suggestions]="autoFilteredValue"
+                [isLoading]="isLoading"
+                [pageResponse]="pageResponse"
+                [(fieldKey)]="repoTeamId"
+            />
         </div>
         <div class="filter-item">
-            <p-iftalabel>
-                <p-autocomplete
-                    [style]="{ width: '100%' }"
-                    [suggestions]="autoFilteredValue"
-                    optionLabel="name"
-                    dataKey="externalId"
-                    forceSelection
-                    placeholder="Start typing the team name"
-                    dropdown
-                    lazy="true"
-                    display="chip"
-                    fluid
-                    (onSelect)="onSelectUserTeam($event)"
-                    (onClear)="onClearUserTeam($event)"
-                    (completeMethod)="filterTeamRepository($event)"
-                    inputId="repoTeamLookup2"
-                ></p-autocomplete>
-                <label for="repoTeamLookup2">Filter by team activities:</label>
-            </p-iftalabel>
+            <app-paginated-lookup
+                [lookupOptions]="userTeamLookupOptions"
+                (onLoadData)="loadTeamData($event)"
+                [suggestions]="autoFilteredValue"
+                [isLoading]="isLoading"
+                [pageResponse]="pageResponse"
+                [(fieldKey)]="userTeamId"
+            />
         </div>
     </div>
     <ng-template #footer>

--- a/frontend/src/app/pages/dashboard/components/outliers-table/outliers-table.component.html
+++ b/frontend/src/app/pages/dashboard/components/outliers-table/outliers-table.component.html
@@ -1,16 +1,19 @@
 <p-card header="Outliers">
     <p-table
         [value]="outliers"
-        [tableStyle]="{ 'min-width': '50rem' }"
-        [scrollable]="true"
+        [tableStyle]="{ width: '100%' }"
         styleClass="mt-4"
         sortMode="multiple"
+        [scrollable]="true"
         paginator="true"
-        [rows]="7"
+        [rows]="10"
     >
         <ng-template #header>
             <tr>
-                <th pSortableColumn="outlierField">
+                <th
+                    pSortableColumn="outlierField"
+                    style="width: auto; white-space: nowrap"
+                >
                     <div class="flex items-center">
                         <p-sortIcon
                             field="outlierField"
@@ -53,7 +56,10 @@
                         </p-columnFilter>
                     </div>
                 </th>
-                <th pSortableColumn="outlierValue">
+                <th
+                    pSortableColumn="outlierValue"
+                    style="width: auto; white-space: nowrap"
+                >
                     <div class="flex items-center">
                         <p-sortIcon
                             field="outlierValue"
@@ -62,7 +68,9 @@
                         <span class="mr-2">Value</span>
                     </div>
                 </th>
-                <th><div class="flex justify-between items-center">PR</div></th>
+                <th style="width: auto; white-space: nowrap">
+                    <div class="flex justify-between items-center">PR</div>
+                </th>
             </tr>
         </ng-template>
         <ng-template #body let-outlier>

--- a/frontend/src/app/pages/dashboard/components/pull-request-graph/pull-request-graph.component.html
+++ b/frontend/src/app/pages/dashboard/components/pull-request-graph/pull-request-graph.component.html
@@ -12,6 +12,7 @@
                 [data]="lineChartData"
                 [options]="lineChartOptions"
                 height="100%"
+                ariaLabel="PR Metric analysis graph"
             >
             </p-chart>
         </div>

--- a/frontend/src/app/pages/dashboard/components/reviewer-density-graph/reviewer-density-graph.component.html
+++ b/frontend/src/app/pages/dashboard/components/reviewer-density-graph/reviewer-density-graph.component.html
@@ -6,6 +6,7 @@
         [options]="barChartOptions"
         [plugins]="barChartPlugins"
         height="300px"
+        ariaLabel="Reviewer density graph"
     >
     </p-chart>
     <ng-template #footer></ng-template>

--- a/frontend/src/app/pages/service/report/models/lazy-search-response.ts
+++ b/frontend/src/app/pages/service/report/models/lazy-search-response.ts
@@ -1,0 +1,6 @@
+export interface LazySearchResponse<T> {
+    totalItems: number;
+    totalPages: number;
+    currentPage: number;
+    data: T[];
+}

--- a/frontend/src/app/pages/service/report/models/page-filter.ts
+++ b/frontend/src/app/pages/service/report/models/page-filter.ts
@@ -1,0 +1,5 @@
+export interface PageFilter {
+    page: number;
+    size: number;
+    order?: string;
+}

--- a/frontend/src/app/pages/service/report/models/teams-paginated.ts
+++ b/frontend/src/app/pages/service/report/models/teams-paginated.ts
@@ -1,0 +1,4 @@
+import { LazySearchResponse } from './lazy-search-response';
+import { Team } from './team';
+
+export interface TeamsPaginated extends LazySearchResponse<Team> {}

--- a/frontend/src/app/pages/service/report/teams-repository.service.ts
+++ b/frontend/src/app/pages/service/report/teams-repository.service.ts
@@ -2,22 +2,30 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
-import { Team } from './models/team';
+import { PageFilter } from './models/page-filter';
+import { TeamsPaginated } from './models/teams-paginated';
 
 @Injectable({
     providedIn: 'root'
 })
 export class TeamsRepositoryService {
     private readonly baseUrl = 'http://localhost:8080/code-review';
-    private readonly apiVersion = '1.0';
 
     constructor(private http: HttpClient) {}
 
-    getTeamsByDescription(description: string): Observable<Team[]> {
-        const params = new HttpParams()
+    getTeamsByDescription(
+        description: string,
+        pageFilter: PageFilter
+    ): Observable<TeamsPaginated> {
+        let params = new HttpParams()
             .set('teamName', description)
-            .set('api-version', this.apiVersion);
+            .set('page', pageFilter.page)
+            .set('size', pageFilter.size);
 
-        return this.http.get<Team[]>(`${this.baseUrl}/api/teams`, { params });
+        if (pageFilter.order) params = params.set('order', pageFilter.order);
+
+        return this.http.get<TeamsPaginated>(`${this.baseUrl}/api/teams`, {
+            params
+        });
     }
 }

--- a/frontend/src/app/shared/components/paginated-lookup/paginated-lookup.component.html
+++ b/frontend/src/app/shared/components/paginated-lookup/paginated-lookup.component.html
@@ -1,0 +1,23 @@
+<p-iftalabel>
+    <p-autocomplete
+        [inputId]="lookupOptions.inputId"
+        [style]="{ width: '100%' }"
+        [suggestions]="suggestions"
+        (completeMethod)="onCompleteMethod($event)"
+        (onLazyLoad)="onLazyLoad($event)"
+        (onSelect)="onSelectItem($event)"
+        (onClear)="onClearSelection($event)"
+        [dropdown]="true"
+        [lazy]="true"
+        [virtualScroll]="true"
+        [virtualScrollItemSize]="30"
+        [optionLabel]="lookupOptions.optionLabel"
+        [dataKey]="lookupOptions.dataKey"
+        [forceSelection]="true"
+        [placeholder]="lookupOptions.placeholder"
+        display="chip"
+        [fluid]="true"
+        [showClear]="true"
+    ></p-autocomplete>
+    <label [for]="lookupOptions.inputId">Filter by team activities:</label>
+</p-iftalabel>

--- a/frontend/src/app/shared/components/paginated-lookup/paginated-lookup.component.spec.ts
+++ b/frontend/src/app/shared/components/paginated-lookup/paginated-lookup.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PaginatedLookupComponent } from './paginated-lookup.component';
+
+describe('PaginatedLookupComponent', () => {
+  let component: PaginatedLookupComponent;
+  let fixture: ComponentFixture<PaginatedLookupComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PaginatedLookupComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PaginatedLookupComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/shared/components/paginated-lookup/paginated-lookup.component.ts
+++ b/frontend/src/app/shared/components/paginated-lookup/paginated-lookup.component.ts
@@ -1,0 +1,111 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+    AutoCompleteDropdownClickEvent,
+    AutoCompleteLazyLoadEvent,
+    AutoCompleteModule,
+    AutoCompleteSelectEvent
+} from 'primeng/autocomplete';
+import { IftaLabelModule } from 'primeng/iftalabel';
+
+@Component({
+    selector: 'app-paginated-lookup',
+    imports: [AutoCompleteModule, IftaLabelModule],
+    templateUrl: './paginated-lookup.component.html',
+    styleUrl: './paginated-lookup.component.scss'
+})
+export class PaginatedLookupComponent {
+    @Input()
+    public lookupOptions!: LookupOptions;
+
+    @Input()
+    public suggestions!: any[];
+
+    @Input()
+    public isLoading: boolean = false;
+
+    @Input()
+    public pageResponse!: PageResponse;
+
+    @Input()
+    public fieldKey!: any;
+
+    @Output()
+    public fieldKeyChange: EventEmitter<any> = new EventEmitter<any>();
+
+    @Output()
+    public onLoadData: EventEmitter<LazyQuery> = new EventEmitter<LazyQuery>();
+
+    @Output()
+    public onSelect: EventEmitter<AutoCompleteSelectEvent> =
+        new EventEmitter<AutoCompleteSelectEvent>();
+
+    @Output()
+    public onClear: EventEmitter<Event | undefined> = new EventEmitter<
+        Event | undefined
+    >();
+
+    protected autoFilteredValue!: any[];
+
+    private lastQuery: string = '';
+    private pageSize: number = 0;
+
+    protected onSelectItem($event: AutoCompleteSelectEvent) {
+        this.fieldKey = $event.value[this.lookupOptions.dataKey];
+        this.fieldKeyChange.emit(this.fieldKey);
+        this.onSelect.emit($event);
+    }
+
+    protected onClearSelection($event: Event | undefined) {
+        this.fieldKey = null;
+        this.fieldKeyChange.emit(this.fieldKey);
+        this.onClear.emit($event);
+    }
+
+    protected onCompleteMethod(event: AutoCompleteDropdownClickEvent): void {
+        this.lastQuery = event.query;
+        this.pageResponse.currentPage = 0;
+        this.onLoadData.emit({
+            page: 0,
+            size: this.pageSize,
+            params: event.query,
+            lazyCall: false
+        });
+    }
+
+    protected onLazyLoad(event: AutoCompleteLazyLoadEvent): void {
+        const page = this.pageResponse.currentPage + 1;
+        if (event.last != this.suggestions.length) return;
+
+        if (page > this.pageResponse.totalPages) return;
+
+        if (this.isLoading) return;
+
+        this.onLoadData.emit({
+            page: page,
+            size: this.pageSize,
+            params: this.lastQuery,
+            lazyCall: true
+        });
+    }
+}
+
+export interface LazyQuery {
+    params: any;
+    page: number;
+    size: number;
+    order?: string;
+    lazyCall: boolean;
+}
+
+export interface PageResponse {
+    totalItems: number;
+    totalPages: number;
+    currentPage: number;
+}
+
+export interface LookupOptions {
+    placeholder: string;
+    dataKey: string;
+    optionLabel: string;
+    inputId: string | undefined;
+}


### PR DESCRIPTION
This is important to avoid full scan when trying to select just on team on combo lookups. Also, when we work on crud for teams, this will be also relevant for performance.